### PR TITLE
#28 Added definitions for MeanTimeBetweenFailures and MeantimeToRecovery

### DIFF
--- a/src/main/requs/main.req
+++ b/src/main/requs/main.req
@@ -1,5 +1,11 @@
 System is "a web hosting that deploys itself".
 
+MeanTimeBetweenFailures is "time that System spends in continuous up time between one failure and the next failure.
+MTBF is a measure of System reliability via continuous operation and therefore the MTBF target should be set at the highest achievable number. Users will not be notified of failures or down time".
+
+MeanTimeToRecovery is "time that System spends in unscheduled down time until recovery as a result of failure. 
+MTTR is a measure of System reliability via service recovery and therefore the MTTR target should be set at the lowest achievable number".
+
 7c7d96:UC1 is specified.
 7c7d96:UC1 is a must.
 UC1 where User (a user) hosts Repository (a repo):


### PR DESCRIPTION
PR based on issue #28 and #118
