### PR TITLE
Detailed UC8 (standalone Thindeck installation).

### DIFF
--- a/src/main/requs/app.req
+++ b/src/main/requs/app.req
@@ -11,5 +11,6 @@ UC8 where Hoster(a hoster) creates standalone thindeck installation:
     3. The hoster "starts the system as a Java standalone app, or a Linux service, or something similar";
     4. The hoster creates System(a system);
     5. The system "is now running as a standalone app on hoster's machine. It uses its local database and local Docker installation. That means that no object in the system will depend on any other Thindeck installation, including our own which we provide as a service. This applies to user profiles, repositories, Docker containers, etc.".
+UC8/PRICING must "Standalone Thindeck installation is completely free.
     Thindeck, as a software product, is open source. Anyone should be
     able to download and install it locally, on his own server(s)".


### PR DESCRIPTION
Also, renamed the use case and lowered its priority to "should".
This PR is related to #74
