### PR TITLE
Made UC4/1 more formal by using elementary use case "reads".

### DIFF
--- a/src/main/requs/main.req
+++ b/src/main/requs/main.req
@@ -144,7 +144,7 @@ UC3 where Repository deploys itself:
 :UC4 is specified.
 :UC4 is a must.
 UC4 where User reads deployment logs using Repository(a repo):
-    1. The system reads Deployment(a deployments) "all deployments of the repo. TODO: replace with 'lists' elementary use case after requs bug is fixed";
+    1. The system lists Deployment(a deployments) "all deployments of the repo";
     2. The system "displays a list of deployments that has already been executed";
     3. The user "chooses a deployment and initiates viewing its log";
     4. The system "displays a log for the chosen deployment".


### PR DESCRIPTION
TODO: rename "reads" to "lists" after requs bug is fixed (currently not recognized by requs as elementary use case)
