### PR TITLE
UC2/LOG

### DIFF
--- a/src/main/requs/nfrs.req
+++ b/src/main/requs/nfrs.req
@@ -31,7 +31,7 @@ UC2/PERF must "each physical server should be able to host 4 actively working
 
 UC2/MTBF must "be 30 days".
 
-UC2/LOG must "be kept for 180 days since creation. 
+UC2/LOG must "be kept for 180 days since creation.
   Log is deleted once the 180 day mark is reached".
 
 UC9.1/MTBF must "be 30 days".


### PR DESCRIPTION
Created UC2/LOG to indicate that logs are stale after 180 days and must be deleted
