### PR TITLE
#417: add new repo test

### DIFF
--- a/src/main/java/com/thindeck/dynamo/DyRepos.java
+++ b/src/main/java/com/thindeck/dynamo/DyRepos.java
@@ -45,7 +45,6 @@ import java.io.IOException;
  * Dynamo implementation of {@link Repos}.
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
- * @todo #370 Create test for #add new repo
  */
 public final class DyRepos implements Repos {
     /**


### PR DESCRIPTION
IMHO, there are already `com.thindeck.dynamo.DyReposTest#addNewRepo` and `com.thindeck.dynamo.DyReposTest#addExistingRepo` tests for this method. I don't think any more is needed. Simply removing the puzzle.
Please, review.
